### PR TITLE
Minor

### DIFF
--- a/src/exoscale/lingo.cljc
+++ b/src/exoscale/lingo.cljc
@@ -111,26 +111,26 @@
   (update explain-data
           :clojure.spec.alpha/problems
           (fn [pbs]
-            (-> (sequence (comp
-                           (if message? (x-extend-message opts) identity)
-                           (if path? (x-extend-path opts) identity)
-                           (if highlight? (x-highlight value opts) identity))
-                          ;; the stuff we will always do first, fixing spec bugs,
-                          ;; extending with our spec/pred data. We need to do this
-                          ;; first because of grouping, this way we can avoid to do
-                          ;; useless work that would be squashed by a potential
-                          ;; merge of problems
-                          (cond->> (eduction (x-fix-spec-quirks value)
-                                             (x-extend-spec-data opts)
-                                             (x-extend-pred-data opts)
-                                             pbs)
-                            group-missing-keys?
-                            impl/group-missing-keys
+            (sequence (comp
+                       (if message? (x-extend-message opts) identity)
+                       (if path? (x-extend-path opts) identity)
+                       (if highlight? (x-highlight value opts) identity))
+                      ;; the stuff we will always do first, fixing spec bugs,
+                      ;; extending with our spec/pred data. We need to do this
+                      ;; first because of grouping, this way we can avoid to do
+                      ;; useless work that would be squashed by a potential
+                      ;; merge of problems
+                      (cond->> (eduction (x-fix-spec-quirks value)
+                                         (x-extend-spec-data opts)
+                                         (x-extend-pred-data opts)
+                                         pbs)
+                        group-missing-keys?
+                        impl/group-missing-keys
 
-                            group-or-problems?
-                            impl/group-or-problems
+                        group-or-problems?
+                        impl/group-or-problems
 
-                            :then (sort-by #(- (count (:path %))))))))))
+                        :then (sort-by #(- (count (:path %)))))))))
 
 (defn explain-data
   ([spec value]

--- a/src/exoscale/lingo/highlight.cljc
+++ b/src/exoscale/lingo/highlight.cljc
@@ -116,27 +116,27 @@
     :exoscale.lingo.explain/keys [message]
     :or {message (str "Does not conform to " pred)}}
    {:as opts :keys [colors? highlight-inline-message?]}]
-  (cond-> (->> (prep-val value in opts)
-               str/split-lines
-               (transduce (comp
-                           (map (fn [line]
-                                   ;; if line contains relevant value, add placholder
-                                   ;; with rendered error
-                                  (if-let [idx (relevant-mark-index line)]
-                                    (let [s (pp-str val)]
-                                      (str (replace-mark line
-                                                         (cond-> s
-                                                           colors?
-                                                           (u/color :red))
-                                                         idx)
-                                           \newline
-                                           (cond-> (str (marker idx (width s)))
+  (->> (prep-val value in opts)
+       str/split-lines
+       (transduce (comp
+                   (map (fn [line]
+                          ;; if line contains relevant value, add placholder
+                          ;; with rendered error
+                          (if-let [idx (relevant-mark-index line)]
+                            (let [s (pp-str val)]
+                              (str (replace-mark line
+                                                 (cond-> s
+                                                   colors?
+                                                   (u/color :red))
+                                                 idx)
+                                   \newline
+                                   (cond-> (str (marker idx (width s)))
 
-                                             highlight-inline-message?
-                                             (str " " message)
+                                     highlight-inline-message?
+                                     (str " " message)
 
-                                             colors?
-                                             (u/color :red))))
-                                    line)))
-                           (interpose \newline))
-                          u/string-builder))))
+                                     colors?
+                                     (u/color :red))))
+                            line)))
+                   (interpose \newline))
+                  u/string-builder)))

--- a/test/exoscale/lingo/test/core_test.cljc
+++ b/test/exoscale/lingo/test/core_test.cljc
@@ -200,9 +200,7 @@
     {:age 10 :person {:names [1]}}
     "1 in `person.names[0]` is an invalid :foo/name - should be a String\n"
 
-    (-> (s/def :foo/agent2 (s/keys :req-un [:foo/person :foo/age]))
-        ;; (xs/with-meta! {:exoscale.lingo/name "Agent"})
-        )
+    (s/def :foo/agent2 (s/keys :req-un [:foo/person :foo/age])) ;; (xs/with-meta! {:exoscale.lingo/name "Agent"})
     {:age ""}
     "\"\" in `age` is an invalid :foo/age - should be an Integer\n{:age \"\"} is an invalid :foo/agent2 - missing key :person\n"
 


### PR DESCRIPTION
As I noticed https://github.com/exoscale/lingo/commit/a63ac6adb8df0f8ea4917b42ef21ab767ef15aef I wondered if Eastwood would have found out about it and indeed:

```
~/lingo (94eb442) $ lein eastwood
== Eastwood 1.1.1 Clojure 1.10.3 JVM 16.0.1 ==
Unknown error: {:reason :eastwood.copieddeps.dep9.clojure.tools.namespace.dependency/circular-dependency, :node exoscale.lingo, :dependency exoscale.lingo}
Subprocess failed
```

That is fixed now, anyway I went and fixed these other minor ones:

```
== Linting exoscale.lingo.utils ==
src/exoscale/lingo/utils.cljc:16:8: local-shadows-var: local: color invoked as function shadows var: #'exoscale.lingo.utils/color.
== Linting exoscale.lingo.impl ==
== Linting exoscale.lingo.highlight ==
src/exoscale/lingo/highlight.cljc:119:3: suspicious-expression: cond-> called with 1 args. (cond-> x) always returns x. Perhaps there are misplaced parentheses?
== Linting exoscale.lingo ==
src/exoscale/lingo.cljc:114:13: suspicious-expression: -> called with 1 args. (-> x) always returns x. Perhaps there are misplaced parentheses?
== Linting exoscale.lingo.test.core-test ==
test/exoscale/lingo/test/core_test.cljc:203:5: suspicious-expression: -> called with 1 args. (-> x) always returns x. Perhaps there are misplaced parentheses?
```

Cheers - V