### PR TITLE
fix undeclared ns warning

### DIFF
--- a/src/exoscale/lingo.cljc
+++ b/src/exoscale/lingo.cljc
@@ -5,6 +5,8 @@
             [exoscale.lingo.utils :as u]
             [exoscale.lingo.impl :as impl]))
 
+(create-ns 'exoscale.lingo.pred)
+
 (def registry-ref
   (atom (merge #:exoscale.lingo.registry.spec{:message {}}
                #:exoscale.lingo.registry.pred{:conformers #{}


### PR DESCRIPTION
```clj
------ WARNING #1 - :undeclared-ns ---------------------------------------------
 Resource: exoscale/lingo.cljc:425:18
--------------------------------------------------------------------------------
 422 |                  (fn [[_ {:keys [min max]}] _opts]
 423 |                    (impl/format "should be an Integer between %d and %d" min max)))
 424 | 
 425 | (set-pred-error! (s/def :exoscale.lingo.pred/no-method
------------------------^-------------------------------------------------------
 No such namespace: exoscale.lingo.pred, could not locate exoscale/lingo/pred.cljs, exoscale/lingo/pred.cljc, or JavaScript source providing "exoscale.lingo.pred"
--------------------------------------------------------------------------------
 426 |                    (s/cat :_ #{'exoscale.lingo.pred/no-method}
 427 |                           :method ident?))
 428 |                  (fn [{:keys [method]} _opts]
 429 |                    (impl/format "should allow dispatch on %s" method)))
--------------------------------------------------------------------------------
```