### PR TITLE
Bump pp to v2023-11-25.47

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -6,7 +6,7 @@
                                  :repository "clojars"}
 
  :deps {org.clojure/clojure {:mvn/version "1.11.1"}
-        me.flowthing/pp {:mvn/version "2023-10-05.5"}}
+        me.flowthing/pp {:mvn/version "2023-11-25.47"}}
 
  :aliases
  {:project {:deps {io.github.exoscale/tools.project {:git/sha "5f24196ebea4dc6e601d201d97b463ea26923c7e"}}

--- a/src/exoscale/lingo/highlight.cljc
+++ b/src/exoscale/lingo/highlight.cljc
@@ -1,6 +1,5 @@
 (ns exoscale.lingo.highlight
-  (:require #?(:cljs [clojure.pprint :as pp]
-               :clj [me.flowthing.pp :as pp])
+  (:require [me.flowthing.pp :as pp]
             [clojure.string :as str]
             [exoscale.lingo.utils :as u]))
 


### PR DESCRIPTION
v2023-11-25.47 supports ClojureScript.

Both Clojure and ClojureScript tests pass on my machine after this change.